### PR TITLE
Fix steamcmd SEGFAULT without running the server as root

### DIFF
--- a/docker/zomboid-dedicated-server.Dockerfile
+++ b/docker/zomboid-dedicated-server.Dockerfile
@@ -22,7 +22,7 @@
 #######################################################################
 
 # Base Image
-ARG BASE_IMAGE="docker.io/renegademaster/steamcmd-minimal:1.1.2"
+ARG BASE_IMAGE="docker.io/renegademaster/steamcmd-minimal:2.0.0-root"
 
 FROM ${BASE_IMAGE}
 
@@ -37,9 +37,10 @@ COPY src /home/steam/
 
 # Install Python, and take ownership of rcon binary
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3-minimal iputils-ping tzdata \
+        python3-minimal iputils-ping sudo tzdata \
     && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -s /bin/bash -m steam
 
 # Run the setup script
 ENTRYPOINT ["/bin/bash", "/home/steam/run_server.sh"]

--- a/src/run_server.sh
+++ b/src/run_server.sh
@@ -42,7 +42,7 @@ function shutdown() {
 # Start the Server
 function start_server() {
     printf "\n### Starting Project Zomboid Server...\n"
-    timeout "$TIMEOUT" "$BASE_GAME_DIR"/start-server.sh \
+    timeout "$TIMEOUT" sudo -u steam "$BASE_GAME_DIR"/start-server.sh \
         -cachedir="$CONFIG_DIR" \
         -adminusername "$ADMIN_USERNAME" \
         -adminpassword "$ADMIN_PASSWORD" \
@@ -110,6 +110,8 @@ function apply_postinstall_config() {
     # Set the GC for the JVM (advanced, some crashes can be fixed with a different GC algorithm)
     sed -i "s/-XX:+Use.*/-XX:+Use${GC_CONFIG}\",/g" "${SERVER_VM_CONFIG}"
 
+    chown -R steam "${BASE_GAME_DIR}"
+
     printf "\n### Post Install Configuration applied.\n"
 }
 
@@ -134,6 +136,7 @@ function update_server() {
     printf "\n### Updating Project Zomboid Server...\n"
 
     steamcmd.sh +runscript "$STEAM_INSTALL_FILE"
+    chown -R steam "${BASE_GAME_DIR}"
 
     printf "\n### Project Zomboid Server updated.\n"
 }
@@ -144,6 +147,7 @@ function apply_preinstall_config() {
 
     # Set the selected game version
     sed -i "s/beta .* /beta $GAME_VERSION /g" "$STEAM_INSTALL_FILE"
+    chown -R steam "${STEAM_INSTALL_FILE}"
 
     printf "\n### Pre Install Configuration applied.\n"
 }
@@ -239,6 +243,10 @@ function set_variables() {
     SERVER_CONFIG="$CONFIG_DIR/Server/$SERVER_NAME.ini"
     SERVER_VM_CONFIG="$BASE_GAME_DIR/ProjectZomboid64.json"
     SERVER_RULES_CONFIG="$CONFIG_DIR/Server/${SERVER_NAME}_SandboxVars.lua"
+    if [[ ! -d "${CONFIG_DIR}" ]]; then
+        mkdir -p "${CONFIG_DIR}"
+    fi
+    chown -R steam "${CONFIG_DIR}"
 }
 
 ## Main


### PR DESCRIPTION
Resolves an issue with steamcmd.sh encountering a SEGFAULT when running as a non-root user. The server is installed, updated, and managed by the root user, but ownership of the server's files are always relinquished back to the steam user after they are created or modified.

This is more of a band-aid solution, as it would definitely be better to rework the image in such a way that it is not a requirement to constantly `chown` files back to the `steam` user, and also to not run _anything_ as root, but I figure this is a serviceable and minimally-invasive solution to get the image working for now. 

The change modifies the image to be based off of the root variant of the `steamcmd-minimal` image, and then creates a `steam` user manually in the Dockerfile. The `run_server.sh` script is run as root, but the command to run the server is done as the `steam` user. As mentioned above, whenever files required by the server are created or modified (as root) by `run_server.sh`, their ownership is transferred back to the `steam` user.
